### PR TITLE
(fix) Fix pre-commit workflow on main

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -12,9 +12,6 @@ on:
       - ready_for_review
     branches:
       - main
-  push:
-    branches:
-      - main
 
 jobs:
   pre-commit:


### PR DESCRIPTION
Pre-commit workflow is removed from the GitHub action

Closes: https://github.com/cloudopusnet/terraform-aws-simple-ipv4-vpc/issues/15