### PR TITLE
(feat) Add .terraformignore to skip bundling development files.

### DIFF
--- a/.terraformignore
+++ b/.terraformignore
@@ -1,0 +1,6 @@
+.github/
+tests/
+.gitignore
+.tflint.hcl
+mise.toml
+.pre-commit-config.yaml

--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ Simple AWS VPC for test environments and prototype workloads
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9.8 |
 | <a name="requirement_assert"></a> [assert](#requirement\_assert) | >=0.15.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.95 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.97 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.95 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.97 |
 
 ## Modules
 

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.95"
+      version = ">= 5.97"
     }
     assert = {
       source  = "hashicorp/assert"


### PR DESCRIPTION
Plus bump  aws provider

closes: https://github.com/cloudopusnet/terraform-aws-simple-ipv4-vpc/issues/24